### PR TITLE
feat: Preserve original titles in markdown filenames

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude Code
+
+on:
+    issue_comment:
+        types: [created]
+    pull_request_review_comment:
+        types: [created]
+    issues:
+        types: [opened, assigned]
+    pull_request_review:
+        types: [submitted]
+
+jobs:
+    claude:
+        if: |
+            (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+            (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+            (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+            (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: read
+            issues: read
+            id-token: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+
+            - name: Run Claude Code
+              id: claude
+              uses: anthropics/claude-code-action@beta
+              with:
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude_auto_review.yml
+++ b/.github/workflows/claude_auto_review.yml
@@ -1,0 +1,38 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  auto-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Automatic PR Review
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: "60"
+          direct_prompt: |
+            Please review this pull request and provide comprehensive feedback.
+
+            Focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security implications
+            - Test coverage
+            - Documentation updates if needed
+
+            Provide constructive feedback with specific suggestions for improvement.
+            Use inline comments to highlight specific areas of concern.
+          # allowed_tools: "mcp__github__add_pull_request_review_comment"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ wheels/
 
 # Virtual environments
 .venv
+
+# Logs directory
+logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Development
+```bash
+# Install dependencies
+uv sync
+
+# Run development server
+uv run uvicorn main:app --reload
+
+# Run server on specific port
+uv run uvicorn main:app --reload --port 8080
+```
+
+### Docker
+```bash
+# Build Docker image
+docker build -t link-content-scraper .
+
+# Run Docker container
+docker run -p 8080:8080 link-content-scraper
+```
+
+### Deployment
+```bash
+# Deploy to Fly.io
+fly deploy
+```
+
+## Architecture
+
+This is a FastAPI web scraper application that fetches web pages and converts them to markdown using Jina Reader API.
+
+### Key Components
+
+- **FastAPI Application** (`main.py`): Single-file application with all endpoints and logic
+- **Rate Limiting**: Token bucket implementation to respect Jina API limits (15 req/min)
+- **Async Processing**: Uses httpx for concurrent HTTP requests with proper batching
+- **Progress Tracking**: Server-sent events (SSE) for real-time progress updates
+- **Content Processing**: Special handling for PDFs and arXiv papers
+
+### Important Patterns
+
+1. **URL Transformation**: arXiv URLs are automatically transformed to PDF versions for better content extraction
+2. **Content Validation**: Scraped content is validated to ensure it's not empty or metadata-only
+3. **Error Handling**: Implements retry logic with exponential backoff for failed requests
+4. **Batch Processing**: Links are processed in batches of 10 with delays between batches
+5. **Resource Cleanup**: Temporary files and ZIP archives are cleaned up after 5 minutes
+
+### API Endpoints
+
+- `GET /`: Serves the web interface
+- `POST /api/scrape`: Starts a scraping job
+- `GET /api/scrape/progress`: SSE endpoint for progress updates
+- `GET /api/download/{job_id}`: Downloads scraped content as ZIP
+- `POST /cancel/{tracker_id}`: Cancels an ongoing scraping operation
+
+### Configuration Variables
+
+Located in `main.py`:
+- `RATE_LIMIT = 15`: Requests per minute to Jina API
+- `RATE_PERIOD = 60`: Rate limit window in seconds
+- `MAX_RETRIES = 3`: Number of retry attempts
+- `RETRY_DELAY = 5`: Base delay between retries
+- `PDF_TIMEOUT = 60.0`: Timeout for PDF content
+- `DEFAULT_TIMEOUT = 30.0`: Default request timeout

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Integration test for the title preservation feature"""
+
+import sys
+import os
+import tempfile
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from main import create_zip_file, extract_title_from_content, create_safe_filename
+
+def test_zip_file_creation_with_titles():
+    """Test that ZIP files are created with proper title-based filenames"""
+    
+    # Simulate scraped content with various titles
+    test_contents = [
+        (
+            "https://example.com/ml-guide",
+            """# Machine Learning: A Beginner's Guide
+
+## Introduction
+
+Machine learning is a fascinating field that enables computers to learn from data.
+
+### What You'll Learn
+
+1. Basic concepts of ML
+2. Common algorithms
+3. Practical applications
+
+This guide will take you through the fundamentals step by step."""
+        ),
+        (
+            "https://docs.python.org/3/tutorial/",
+            """Title: The Python Tutorial
+
+# The Python Tutorial
+
+Python is an easy to learn, powerful programming language. It has efficient high-level data structures and a simple but effective approach to object-oriented programming.
+
+## 1. Whetting Your Appetite
+
+If you do much work on computers, eventually you find that there's some task you'd like to automate."""
+        ),
+        (
+            "https://arxiv.org/abs/1706.03762",
+            """# Attention Is All You Need
+
+Published: 2017-06-12
+
+## Abstract
+
+The dominant sequence transduction models are based on complex recurrent or convolutional neural networks that include an encoder and a decoder."""
+        ),
+        (
+            "https://example.com/no-title-page",
+            """URL Source: https://example.com/no-title-page
+
+This page doesn't have a proper title header.
+
+It just contains some content without any markdown headers.
+
+But it should still be saved with a hash-based filename."""
+        )
+    ]
+    
+    # Create a temporary job ID and tracker ID
+    job_id = "test-job-123"
+    tracker_id = "test-tracker-456"
+    
+    try:
+        # Create ZIP file
+        zip_path = create_zip_file(test_contents, job_id, tracker_id)
+        
+        print("Testing ZIP file creation with title-based filenames...")
+        print("-" * 50)
+        
+        # Verify ZIP file exists
+        assert Path(zip_path).exists(), f"ZIP file not created at {zip_path}"
+        print("✓ ZIP file created successfully")
+        
+        # Extract and check filenames
+        with zipfile.ZipFile(zip_path, 'r') as zipf:
+            filenames = zipf.namelist()
+            print(f"\n✓ Found {len(filenames)} files in ZIP:")
+            
+            expected_patterns = {
+                "Machine-Learning-A-Beginners-Guide": "Should contain ML guide title",
+                "The-Python-Tutorial": "Should contain Python tutorial title",
+                "Attention-Is-All-You-Need": "Should contain Attention paper title",
+            }
+            
+            for filename in filenames:
+                print(f"  - {filename}")
+                
+                # Check if any expected pattern is in the filename
+                found_pattern = False
+                for pattern, description in expected_patterns.items():
+                    if pattern in filename:
+                        print(f"    ✓ {description}")
+                        found_pattern = True
+                        break
+                
+                if not found_pattern and not filename.endswith(".md"):
+                    print(f"    ⚠ Unexpected filename format")
+                
+                # Verify file has .md extension
+                assert filename.endswith(".md"), f"File {filename} doesn't have .md extension"
+                
+                # Verify no invalid characters
+                invalid_chars = ['/', '\\', ':', '*', '?', '"', '<', '>', '|']
+                for char in invalid_chars:
+                    assert char not in filename, f"Filename {filename} contains invalid character: {char}"
+            
+            print("\n✓ All filenames are valid")
+            
+            # Check file contents
+            print("\nChecking file contents...")
+            for filename in filenames:
+                with zipf.open(filename) as f:
+                    content = f.read().decode('utf-8')
+                    # Verify content starts with original URL
+                    assert content.startswith("# Original URL:"), f"File {filename} doesn't start with URL header"
+                    print(f"  ✓ {filename}: Content properly formatted")
+        
+        # Clean up
+        Path(zip_path).unlink()
+        print("\n✓ Cleanup completed")
+        
+        return True
+        
+    except Exception as e:
+        print(f"\n✗ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_edge_cases():
+    """Test edge cases for filename generation"""
+    
+    print("\n\nTesting edge cases...")
+    print("-" * 50)
+    
+    edge_cases = [
+        {
+            "desc": "Very long title (200+ chars)",
+            "content": "# " + "A" * 200 + "\n\nContent here",
+            "url": "https://example.com/long"
+        },
+        {
+            "desc": "Title with file extensions",
+            "content": "# README.md and CONFIG.yaml Guide\n\nContent",
+            "url": "https://example.com/files"
+        },
+        {
+            "desc": "Title with path separators",
+            "content": "# Unix/Linux vs Windows\\Path Guide\n\nContent",
+            "url": "https://example.com/paths"
+        },
+        {
+            "desc": "Empty content",
+            "content": "",
+            "url": "https://example.com/empty"
+        }
+    ]
+    
+    all_passed = True
+    for case in edge_cases:
+        print(f"\nTesting: {case['desc']}")
+        title = extract_title_from_content(case['content'])
+        filename = create_safe_filename(title, case['url'])
+        
+        print(f"  Title: {title}")
+        print(f"  Filename: {filename}")
+        
+        # Verify filename is valid
+        if not filename.endswith('.md'):
+            print("  ✗ Missing .md extension")
+            all_passed = False
+        
+        if len(filename) > 255:
+            print(f"  ✗ Filename too long: {len(filename)} chars")
+            all_passed = False
+        
+        invalid_chars = ['/', '\\', ':', '*', '?', '"', '<', '>', '|']
+        invalid_found = [c for c in invalid_chars if c in filename]
+        if invalid_found:
+            print(f"  ✗ Contains invalid characters: {invalid_found}")
+            all_passed = False
+        
+        if not invalid_found and len(filename) <= 255 and filename.endswith('.md'):
+            print("  ✓ Valid filename")
+    
+    return all_passed
+
+def main():
+    """Run all integration tests"""
+    print("=" * 50)
+    print("Integration Tests for Title Preservation Feature")
+    print("=" * 50)
+    
+    zip_test_passed = test_zip_file_creation_with_titles()
+    edge_test_passed = test_edge_cases()
+    
+    print("\n" + "=" * 50)
+    if zip_test_passed and edge_test_passed:
+        print("✓ All integration tests passed!")
+        return 0
+    else:
+        print("✗ Some integration tests failed!")
+        return 1
+
+if __name__ == "__main__":
+    # Need to initialize progress_tracker for the test
+    from collections import defaultdict
+    from main import progress_tracker
+    
+    sys.exit(main())

--- a/test_title_extraction.py
+++ b/test_title_extraction.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Test script for title extraction and safe filename generation"""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from main import extract_title_from_content, create_safe_filename
+
+def test_title_extraction():
+    """Test various content formats for title extraction"""
+    
+    test_cases = [
+        # Test case 1: Standard H1 header
+        {
+            "content": """# Introduction to Machine Learning
+
+This is a comprehensive guide to machine learning basics.
+
+## Chapter 1: Getting Started
+
+Machine learning is...""",
+            "expected_title": "Introduction to Machine Learning"
+        },
+        
+        # Test case 2: Title with metadata
+        {
+            "content": """URL Source: https://example.com/article
+Title: Understanding Neural Networks
+
+# Understanding Neural Networks
+
+Neural networks are computational models...""",
+            "expected_title": "Understanding Neural Networks"
+        },
+        
+        # Test case 3: H2 header only
+        {
+            "content": """Some introductory text without header
+
+## FastAPI Documentation
+
+FastAPI is a modern web framework...""",
+            "expected_title": "FastAPI Documentation"
+        },
+        
+        # Test case 4: Title with markdown formatting
+        {
+            "content": """# [Getting Started with **Python**](https://python.org)
+
+Python is a versatile programming language...""",
+            "expected_title": "Getting Started with Python"
+        },
+        
+        # Test case 5: No title
+        {
+            "content": """URL Source: https://example.com
+            
+Just some content without any headers.""",
+            "expected_title": None
+        },
+        
+        # Test case 6: arXiv paper format
+        {
+            "content": """# Attention Is All You Need
+
+Published: 2017-06-12
+
+## Abstract
+
+The dominant sequence transduction models...""",
+            "expected_title": "Attention Is All You Need"
+        }
+    ]
+    
+    print("Testing title extraction...")
+    print("-" * 50)
+    
+    all_passed = True
+    for i, test in enumerate(test_cases, 1):
+        extracted = extract_title_from_content(test["content"])
+        passed = extracted == test["expected_title"]
+        status = "✓" if passed else "✗"
+        
+        print(f"Test {i}: {status}")
+        print(f"  Expected: {test['expected_title']}")
+        print(f"  Got: {extracted}")
+        
+        if not passed:
+            all_passed = False
+        print()
+    
+    return all_passed
+
+def test_safe_filename_creation():
+    """Test safe filename generation"""
+    
+    test_cases = [
+        # Test case 1: Normal title
+        {
+            "title": "Introduction to Machine Learning",
+            "url": "https://example.com/ml-intro",
+            "expected_pattern": r"Introduction-to-Machine-Learning_\d{8}\.md"
+        },
+        
+        # Test case 2: Title with special characters
+        {
+            "title": "What's New in Python 3.12?",
+            "url": "https://python.org/whats-new",
+            "expected_pattern": r"Whats-New-in-Python-312_\d{8}\.md"
+        },
+        
+        # Test case 3: Very long title
+        {
+            "title": "A Comprehensive Guide to Understanding and Implementing Advanced Machine Learning Algorithms for Natural Language Processing Applications in Production Environments",
+            "url": "https://example.com/long-article",
+            "expected_pattern": r"A-Comprehensive-Guide-to-Understanding-and-Implementing-Advanced-Machine-Learning-Algorithms-for-Nat_\d{8}\.md"
+        },
+        
+        # Test case 4: No title (fallback to hash)
+        {
+            "title": None,
+            "url": "https://example.com/no-title",
+            "expected_pattern": r"-?\d+\.md"
+        },
+        
+        # Test case 5: Unicode title
+        {
+            "title": "Café: A Guide to Émigré Literature",
+            "url": "https://example.com/unicode",
+            "expected_pattern": r"Cafe-A-Guide-to-Emigre-Literature_\d{8}\.md"
+        },
+        
+        # Test case 6: Title with only special characters
+        {
+            "title": "!!!???###",
+            "url": "https://example.com/special",
+            "expected_pattern": r"untitled_\d{8}\.md"
+        }
+    ]
+    
+    print("\nTesting safe filename creation...")
+    print("-" * 50)
+    
+    import re
+    all_passed = True
+    
+    for i, test in enumerate(test_cases, 1):
+        filename = create_safe_filename(test["title"], test["url"])
+        pattern = test["expected_pattern"]
+        matches = bool(re.match(pattern, filename))
+        status = "✓" if matches else "✗"
+        
+        print(f"Test {i}: {status}")
+        print(f"  Title: {test['title']}")
+        print(f"  Generated: {filename}")
+        print(f"  Pattern: {pattern}")
+        
+        # Additional checks
+        if matches:
+            # Check filename is valid
+            invalid_chars = ['/', '\\', ':', '*', '?', '"', '<', '>', '|']
+            has_invalid = any(char in filename for char in invalid_chars)
+            if has_invalid:
+                print(f"  WARNING: Filename contains invalid characters!")
+                all_passed = False
+                
+            # Check length
+            if len(filename) > 255:  # Most filesystems limit
+                print(f"  WARNING: Filename too long ({len(filename)} chars)!")
+                all_passed = False
+        else:
+            all_passed = False
+            
+        print()
+    
+    return all_passed
+
+def main():
+    """Run all tests"""
+    print("=" * 50)
+    print("Title Extraction and Filename Generation Tests")
+    print("=" * 50)
+    
+    title_tests_passed = test_title_extraction()
+    filename_tests_passed = test_safe_filename_creation()
+    
+    print("\n" + "=" * 50)
+    if title_tests_passed and filename_tests_passed:
+        print("✓ All tests passed!")
+        return 0
+    else:
+        print("✗ Some tests failed!")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Implements title extraction from scraped content to create descriptive filenames
- Replaces hash-based filenames with title-based filenames for better user experience
- Adds comprehensive test coverage for the feature

## Changes
- Added `extract_title_from_content()` function to parse titles from Jina API responses
- Added `create_safe_filename()` function to generate valid filenames from titles
- Updated `create_zip_file()` to use the new title-based naming system
- Added unit tests for title extraction and filename generation
- Added integration tests for the complete feature
- Updated .gitignore to exclude logs directory
- Added CLAUDE.md for project documentation
- Added GitHub Actions workflows

## Test Plan
All tests pass:
- ✓ Title extraction from various content formats (H1, H2, Title: format)
- ✓ Safe filename generation with edge cases (special chars, unicode, long titles)
- ✓ Integration test verifying ZIP file creation with proper filenames
- ✓ Edge case testing for malformed content

## Example
Before: Files named like `1234567890.md`
After: Files named like `Introduction-to-Machine-Learning_a1b2c3.md`

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)