### PR TITLE
test: reach 100% coverage across the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ logs/
 # Dolt database files (added by bd init)
 .dolt/
 *.db
+
+# Coverage artifacts
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -84,3 +84,22 @@ class TestSentryInit:
         create_app()
         assert len(init_calls) == 1
         assert init_calls[0]["dsn"] == "https://fake@sentry.io/123"
+
+    def test_sentry_init_failure_is_swallowed(self, monkeypatch, caplog):
+        """If sentry_sdk.init raises, app startup must continue and log a warning."""
+        import logging
+        import sentry_sdk
+
+        monkeypatch.setattr(config_module, "STRIPE_WEBHOOK_SECRET", "whsec_test")
+        monkeypatch.setattr(config_module, "STRIPE_SECRET_KEY", "sk_test")
+        monkeypatch.setattr(config_module, "SENTRY_DSN", "https://fake@sentry.io/123")
+
+        def _boom(**kwargs):
+            raise RuntimeError("sentry init failed")
+
+        monkeypatch.setattr(sentry_sdk, "init", _boom)
+
+        with caplog.at_level(logging.WARNING):
+            app = create_app()  # must not raise
+        assert app is not None
+        assert any("Sentry initialization failed" in m for m in caplog.messages)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -172,3 +172,353 @@ class TestRequireApiKey:
         else:
             assert resets_at.year == now.year
             assert resets_at.month == now.month + 1
+
+    def test_unknown_tier_returns_500(self):
+        weird_customer = Customer(
+            stripe_customer_id="cus_weird",
+            email="weird@example.com",
+            tier="platinum",
+            active=True,
+        )
+        mock_db = MockDatabaseClient(customer=weird_customer)
+        client = _make_client(mock_db)
+
+        resp = client.post("/test", headers={"x-api-key": VALID_KEY})
+
+        assert resp.status_code == 500
+        assert "configuration" in resp.json()["detail"].lower()
+
+
+# -- DatabaseClient unit tests -------------------------------------------------
+
+class _Result:
+    def __init__(self, data):
+        self.data = data
+
+
+class _Chain:
+    """Chainable fake supabase query builder. Returns ``self`` for everything
+    except ``execute()``, which returns an awaitable resolving to ``response``.
+    Calls are recorded so tests can verify the chain.
+    """
+
+    def __init__(self, response):
+        self._response = response
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    def __getattr__(self, name):
+        if name == "execute":
+            async def _exec():
+                return self._response
+            return _exec
+
+        def _method(*args, **kwargs):
+            self.calls.append((name, args, kwargs))
+            return self
+        return _method
+
+
+class _SupabaseMock:
+    def __init__(self):
+        self.table_chains: dict[str, _Chain] = {}
+        self.rpc_chains: dict[str, _Chain] = {}
+        self.last_table: str | None = None
+        self.last_rpc: tuple[str, dict] | None = None
+
+    def set_table_response(self, name: str, response):
+        self.table_chains[name] = _Chain(response)
+
+    def set_rpc_response(self, name: str, response):
+        self.rpc_chains[name] = _Chain(response)
+
+    def table(self, name: str):
+        self.last_table = name
+        if name not in self.table_chains:
+            self.table_chains[name] = _Chain(_Result(None))
+        return self.table_chains[name]
+
+    def rpc(self, name: str, params: dict):
+        self.last_rpc = (name, params)
+        if name not in self.rpc_chains:
+            self.rpc_chains[name] = _Chain(_Result(None))
+        return self.rpc_chains[name]
+
+
+@pytest.fixture()
+def db_with_mock():
+    from link_content_scraper.auth import DatabaseClient
+
+    db = DatabaseClient()
+    supabase = _SupabaseMock()
+    db._supabase = supabase
+    return db, supabase
+
+
+class TestDatabaseClientCustomerByKey:
+    async def test_returns_customer_when_key_active_and_customer_active(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("api_keys", _Result({
+            "active": True,
+            "customers": {
+                "stripe_customer_id": "cus_x",
+                "email": "x@example.com",
+                "tier": "pro",
+                "active": True,
+            },
+        }))
+        result = await db.get_customer_by_key("hash_value")
+        assert result is not None
+        assert result.stripe_customer_id == "cus_x"
+        assert result.tier == "pro"
+        assert result.active is True
+
+    async def test_inactive_when_key_inactive(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("api_keys", _Result({
+            "active": False,
+            "customers": {
+                "stripe_customer_id": "cus_x",
+                "email": "x@example.com",
+                "tier": "pro",
+                "active": True,
+            },
+        }))
+        result = await db.get_customer_by_key("hash_value")
+        assert result.active is False
+
+    async def test_returns_none_when_no_result(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("api_keys", _Result(None))
+        result = await db.get_customer_by_key("hash_value")
+        assert result is None
+
+    async def test_returns_none_when_result_is_none_object(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("api_keys", None)
+        result = await db.get_customer_by_key("hash_value")
+        assert result is None
+
+    async def test_returns_none_when_customer_orphaned(self, db_with_mock, caplog):
+        import logging
+
+        db, sb = db_with_mock
+        sb.set_table_response("api_keys", _Result({
+            "active": True,
+            "customers": None,
+        }))
+        with caplog.at_level(logging.ERROR, logger="link_content_scraper.auth"):
+            result = await db.get_customer_by_key("hash_value")
+        assert result is None
+        assert any("orphaned" in m for m in caplog.messages)
+
+
+class TestDatabaseClientUsage:
+    async def test_get_usage_returns_count(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("usage", _Result({"url_count": 42}))
+        assert await db.get_usage("cus_x", "2026-04") == 42
+
+    async def test_get_usage_returns_zero_when_missing(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("usage", _Result(None))
+        assert await db.get_usage("cus_x", "2026-04") == 0
+
+    async def test_get_usage_returns_zero_when_result_is_none(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("usage", None)
+        assert await db.get_usage("cus_x", "2026-04") == 0
+
+    async def test_increment_usage_calls_rpc(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_rpc_response("increment_usage", _Result(None))
+        await db.increment_usage("cus_x", "2026-04")
+        assert sb.last_rpc == (
+            "increment_usage",
+            {"p_customer_id": "cus_x", "p_month": "2026-04"},
+        )
+
+
+class TestDatabaseClientCustomerCRUD:
+    async def test_create_customer(self, db_with_mock):
+        db, sb = db_with_mock
+        await db.create_customer("cus_new", "new@example.com", "starter")
+        assert sb.last_table == "customers"
+        chain = sb.table_chains["customers"]
+        # First call after table() is insert(...)
+        assert chain.calls[0][0] == "insert"
+        assert chain.calls[0][1][0] == {
+            "stripe_customer_id": "cus_new",
+            "email": "new@example.com",
+            "tier": "starter",
+        }
+
+    async def test_create_api_key(self, db_with_mock):
+        db, sb = db_with_mock
+        await db.create_api_key("hash123", "cus_x")
+        assert sb.last_table == "api_keys"
+        chain = sb.table_chains["api_keys"]
+        assert chain.calls[0][0] == "insert"
+
+    async def test_update_customer_tier(self, db_with_mock):
+        db, sb = db_with_mock
+        await db.update_customer_tier("cus_x", "pro")
+        chain = sb.table_chains["customers"]
+        assert ("update", ({"tier": "pro"},), {}) in chain.calls
+
+    async def test_deactivate_customer_keys(self, db_with_mock):
+        db, sb = db_with_mock
+        await db.deactivate_customer_keys("cus_x")
+        chain = sb.table_chains["api_keys"]
+        assert ("update", ({"active": False},), {}) in chain.calls
+
+    async def test_set_customer_active_true(self, db_with_mock):
+        db, sb = db_with_mock
+        await db.set_customer_active("cus_x", True)
+        chain = sb.table_chains["customers"]
+        assert ("update", ({"active": True},), {}) in chain.calls
+
+    async def test_reactivate_customer_keys(self, db_with_mock):
+        db, sb = db_with_mock
+        await db.reactivate_customer_keys("cus_x")
+        chain = sb.table_chains["api_keys"]
+        assert ("update", ({"active": True},), {}) in chain.calls
+
+    async def test_delete_customer(self, db_with_mock):
+        db, sb = db_with_mock
+        await db.delete_customer("cus_x")
+        chain = sb.table_chains["customers"]
+        names = [c[0] for c in chain.calls]
+        assert "delete" in names
+
+
+class TestDatabaseClientLookups:
+    async def test_get_customer_by_email_found(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("customers", _Result({
+            "stripe_customer_id": "cus_y",
+            "email": "y@example.com",
+            "tier": "free",
+            "active": True,
+        }))
+        result = await db.get_customer_by_email("y@example.com")
+        assert result.stripe_customer_id == "cus_y"
+        assert result.email == "y@example.com"
+
+    async def test_get_customer_by_email_not_found(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("customers", _Result(None))
+        assert await db.get_customer_by_email("missing@example.com") is None
+
+    async def test_get_customer_by_email_none_result(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("customers", None)
+        assert await db.get_customer_by_email("missing@example.com") is None
+
+    async def test_get_customer_by_id_found(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("customers", _Result({
+            "stripe_customer_id": "cus_z",
+            "email": "z@example.com",
+            "tier": "pro",
+            "active": False,
+        }))
+        result = await db.get_customer_by_id("cus_z")
+        assert result.tier == "pro"
+        assert result.active is False
+
+    async def test_get_customer_by_id_not_found(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("customers", _Result(None))
+        assert await db.get_customer_by_id("cus_missing") is None
+
+    async def test_get_customer_by_id_none_result(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("customers", None)
+        assert await db.get_customer_by_id("cus_missing") is None
+
+    async def test_has_api_key_for_customer_true(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("api_keys", _Result([{"key_hash": "h"}]))
+        assert await db.has_api_key_for_customer("cus_x") is True
+
+    async def test_has_api_key_for_customer_false_empty(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("api_keys", _Result([]))
+        assert await db.has_api_key_for_customer("cus_x") is False
+
+    async def test_has_api_key_for_customer_false_none(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("api_keys", None)
+        assert await db.has_api_key_for_customer("cus_x") is False
+
+
+class TestDatabaseClientPendingKeys:
+    async def test_store_pending_key(self, db_with_mock):
+        db, sb = db_with_mock
+        await db.store_pending_key("sess_1", "raw_key", "buyer@example.com", ttl_hours=1)
+        chain = sb.table_chains["pending_keys"]
+        upserts = [c for c in chain.calls if c[0] == "upsert"]
+        assert upserts, "Expected upsert call"
+        payload = upserts[0][1][0]
+        assert payload["session_id"] == "sess_1"
+        assert payload["raw_key"] == "raw_key"
+        assert payload["email"] == "buyer@example.com"
+        assert "expires_at" in payload
+
+    async def test_claim_pending_key_success(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("pending_keys", _Result({
+            "raw_key": "the_key",
+            "email": "buyer@example.com",
+        }))
+        result = await db.claim_pending_key("sess_1", "buyer@example.com")
+        assert result == "the_key"
+
+    async def test_claim_pending_key_not_found(self, db_with_mock, caplog):
+        import logging
+
+        db, sb = db_with_mock
+        sb.set_table_response("pending_keys", _Result(None))
+        with caplog.at_level(logging.WARNING, logger="link_content_scraper.auth"):
+            result = await db.claim_pending_key("sess_missing", "buyer@example.com")
+        assert result is None
+        assert any("not found" in m.lower() or "expired" in m.lower() for m in caplog.messages)
+
+    async def test_claim_pending_key_none_result(self, db_with_mock):
+        db, sb = db_with_mock
+        sb.set_table_response("pending_keys", None)
+        assert await db.claim_pending_key("sess_missing", "buyer@example.com") is None
+
+    async def test_claim_pending_key_email_mismatch(self, db_with_mock, caplog):
+        import logging
+
+        db, sb = db_with_mock
+        sb.set_table_response("pending_keys", _Result({
+            "raw_key": "the_key",
+            "email": "real@example.com",
+        }))
+        with caplog.at_level(logging.WARNING, logger="link_content_scraper.auth"):
+            result = await db.claim_pending_key("sess_1", "wrong@example.com")
+        assert result is None
+        assert any("email mismatch" in m.lower() for m in caplog.messages)
+
+
+class TestDatabaseClientLazyInit:
+    async def test_get_supabase_caches_client(self, monkeypatch):
+        from link_content_scraper import auth as auth_module
+
+        created = []
+
+        async def fake_acreate_client(url, key):
+            created.append((url, key))
+            return _SupabaseMock()
+
+        monkeypatch.setattr("supabase.acreate_client", fake_acreate_client)
+        monkeypatch.setattr(auth_module, "SUPABASE_URL", "https://fake.supabase.co")
+        monkeypatch.setattr(auth_module, "SUPABASE_KEY", "fake_key")
+
+        db = auth_module.DatabaseClient()
+        c1 = await db._get_supabase()
+        c2 = await db._get_supabase()
+        assert c1 is c2
+        assert len(created) == 1

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -379,3 +379,81 @@ class TestCheckoutIdempotency:
 
         assert any("tier" in msg for msg in caplog.messages)
         assert mock_db.customers["cus_notier"]["tier"] == "starter"
+
+
+# -- Webhook payload-parsing & provisioning failure paths ----------------------
+
+class TestHandleWebhookPayloadFailures:
+    @pytest.mark.asyncio
+    async def test_invalid_json_payload_re_raises_value_error(self, caplog):
+        import logging
+
+        with patch(
+            "stripe.Webhook.construct_event",
+            side_effect=ValueError("payload is not valid JSON"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="link_content_scraper.billing"):
+                with pytest.raises(ValueError, match="not valid JSON"):
+                    await handle_webhook(b"garbage", "sig")
+        assert any("not valid JSON" in m for m in caplog.messages)
+
+
+class TestCheckoutCompletedProvisioningFailures:
+    @pytest.mark.asyncio
+    async def test_create_customer_failure_re_raises(self, mock_db, monkeypatch, caplog):
+        import logging
+
+        async def boom(*args, **kwargs):
+            raise RuntimeError("DB write failed")
+
+        monkeypatch.setattr(mock_db, "create_customer", boom)
+
+        event = _make_event("checkout.session.completed", {
+            "id": "cs_fail",
+            "customer": "cus_fail",
+            "customer_email": "fail@example.com",
+            "metadata": {"tier": "starter"},
+        })
+        with patch("stripe.Webhook.construct_event", return_value=event):
+            with caplog.at_level(logging.ERROR, logger="link_content_scraper.billing"):
+                with pytest.raises(RuntimeError, match="DB write failed"):
+                    await handle_webhook(b"payload", "sig")
+        assert any("Failed to create customer" in m for m in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_create_api_key_failure_re_raises(self, mock_db, monkeypatch, caplog):
+        import logging
+
+        async def boom(*args, **kwargs):
+            raise RuntimeError("API key insert failed")
+
+        monkeypatch.setattr(mock_db, "create_api_key", boom)
+
+        event = _make_event("checkout.session.completed", {
+            "id": "cs_keyfail",
+            "customer": "cus_keyfail",
+            "customer_email": "keyfail@example.com",
+            "metadata": {"tier": "starter"},
+        })
+        with patch("stripe.Webhook.construct_event", return_value=event):
+            with caplog.at_level(logging.ERROR, logger="link_content_scraper.billing"):
+                with pytest.raises(RuntimeError, match="API key insert failed"):
+                    await handle_webhook(b"payload", "sig")
+        assert any("Failed to create API key" in m for m in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_missing_session_id_logs_error(self, mock_db, caplog):
+        import logging
+
+        event = _make_event("checkout.session.completed", {
+            # No "id" field -> session_id falls back to ""
+            "customer": "cus_nosess",
+            "customer_email": "nosess@example.com",
+            "metadata": {"tier": "starter"},
+        })
+        with patch("stripe.Webhook.construct_event", return_value=event):
+            with caplog.at_level(logging.ERROR, logger="link_content_scraper.billing"):
+                await handle_webhook(b"payload", "sig")
+        assert any("cannot be delivered" in m for m in caplog.messages)
+        # No pending key because session_id was empty
+        assert "" not in mock_db.pending_keys

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -87,6 +87,16 @@ class TestCancel:
             await task
         assert task.cancelled()
 
+    async def test_register_tasks_creates_tracker_if_missing(self, tracker):
+        """register_tasks for a fresh tracker_id must initialize a default state."""
+        task = asyncio.create_task(asyncio.sleep(0))
+        await tracker.register_tasks("brand_new", [task])
+        await task
+        state = await tracker.get("brand_new")
+        assert state is not None
+        assert state["total"] == 0
+        assert task in state["tasks"]
+
     async def test_cancel_returns_false_for_unknown_id(self, tracker):
         result = await tracker.cancel("nope")
         assert result is False

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -461,6 +461,390 @@ class TestBillingStatus:
         assert data["limit"] == 100
 
 
+class TestScrapeErrorHandling:
+    """Cover the HTTPStatusError / generic-error paths in start_scraping."""
+
+    def _setup_auth_mock(self, monkeypatch):
+        import link_content_scraper.auth as auth_module
+
+        _customer = Customer(stripe_customer_id="cus_test", email="t@t.com", tier="pro", active=True)
+
+        class _MockDb:
+            async def get_customer_by_key(self, key_hash):
+                return _customer
+
+            async def get_usage(self, customer_id, month):
+                return 0
+
+        monkeypatch.setattr(auth_module, "db_client", _MockDb())
+
+    def _make_status_error(self, code: int):
+        import httpx
+
+        request = httpx.Request("GET", "http://example.com/test")
+        response = httpx.Response(code, request=request)
+        return httpx.HTTPStatusError(f"HTTP {code}", request=request, response=response)
+
+    def test_403_returns_502_with_blocking_message(self, client, monkeypatch):
+        import link_content_scraper.routes as routes_module
+
+        self._setup_auth_mock(monkeypatch)
+
+        async def _raise(url, tracker_id, job_id, customer_id):
+            raise self._make_status_error(403)
+
+        monkeypatch.setattr(routes_module, "scrape_site", _raise)
+
+        resp = client.post(
+            "/api/scrape",
+            json={"url": "http://example.com/blocked"},
+            headers={"x-api-key": "test-key"},
+        )
+        assert resp.status_code == 502
+        assert "blocking" in resp.json()["detail"].lower() or "403" in resp.json()["detail"]
+
+    def test_404_returns_502_with_not_found_message(self, client, monkeypatch):
+        import link_content_scraper.routes as routes_module
+
+        self._setup_auth_mock(monkeypatch)
+
+        async def _raise(url, tracker_id, job_id, customer_id):
+            raise self._make_status_error(404)
+
+        monkeypatch.setattr(routes_module, "scrape_site", _raise)
+
+        resp = client.post(
+            "/api/scrape",
+            json={"url": "http://example.com/missing"},
+            headers={"x-api-key": "test-key"},
+        )
+        assert resp.status_code == 502
+        assert "not found" in resp.json()["detail"].lower()
+
+    def test_other_status_returns_502_with_generic_message(self, client, monkeypatch):
+        import link_content_scraper.routes as routes_module
+
+        self._setup_auth_mock(monkeypatch)
+
+        async def _raise(url, tracker_id, job_id, customer_id):
+            raise self._make_status_error(500)
+
+        monkeypatch.setattr(routes_module, "scrape_site", _raise)
+
+        resp = client.post(
+            "/api/scrape",
+            json={"url": "http://example.com/oops"},
+            headers={"x-api-key": "test-key"},
+        )
+        assert resp.status_code == 502
+        assert "500" in resp.json()["detail"]
+
+    def test_generic_error_returns_500(self, client, monkeypatch):
+        import link_content_scraper.routes as routes_module
+
+        self._setup_auth_mock(monkeypatch)
+
+        async def _raise(url, tracker_id, job_id, customer_id):
+            raise ValueError("bad data")
+
+        monkeypatch.setattr(routes_module, "scrape_site", _raise)
+
+        resp = client.post(
+            "/api/scrape",
+            json={"url": "http://example.com/oops"},
+            headers={"x-api-key": "test-key"},
+        )
+        assert resp.status_code == 500
+        assert "bad data" in resp.json()["detail"]
+
+    def test_progress_tracker_missing_uses_zero_counts(self, client, monkeypatch, tmp_path):
+        """If the progress tracker is missing after a successful scrape, response uses zeros."""
+        import link_content_scraper.routes as routes_module
+        from link_content_scraper.progress import progress_tracker
+
+        self._setup_auth_mock(monkeypatch)
+
+        zip_file = tmp_path / "job.zip"
+        zip_file.write_bytes(b"PK\x03\x04")
+
+        async def _scrape(url, tracker_id, job_id, customer_id):
+            # Intentionally do NOT init progress_tracker — simulate the bug case.
+            await progress_tracker.remove(tracker_id)
+            return ([url], str(zip_file))
+
+        monkeypatch.setattr(routes_module, "scrape_site", _scrape)
+
+        resp = client.post(
+            "/api/scrape",
+            json={"url": "http://example.com/no-tracker"},
+            headers={"x-api-key": "test-key"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["successful"] == 0
+        assert body["skipped"] == 0
+        assert body["failed"] == 0
+
+
+class TestDownloadSuccess:
+    def _setup_auth_mock(self, monkeypatch):
+        import link_content_scraper.auth as auth_module
+
+        _customer = Customer(stripe_customer_id="cus_test", email="t@t.com", tier="pro", active=True)
+
+        class _MockDb:
+            async def get_customer_by_key(self, key_hash):
+                return _customer
+
+            async def get_usage(self, customer_id, month):
+                return 0
+
+        monkeypatch.setattr(auth_module, "db_client", _MockDb())
+
+    def test_download_returns_file_and_schedules_cleanup(self, client, monkeypatch, tmp_path):
+        """A valid job_id owned by the caller returns the ZIP file and the cleanup task is created."""
+        import time
+        import link_content_scraper.routes as routes_module
+
+        self._setup_auth_mock(monkeypatch)
+
+        zip_file = tmp_path / "owned.zip"
+        zip_file.write_bytes(b"PK\x03\x04valid-zip-bytes")
+        routes_module._results["job_owned"] = {
+            "zip_path": str(zip_file),
+            "customer_id": "cus_test",
+        }
+        # Short, non-zero delay so the FileResponse can finish streaming before cleanup runs.
+        monkeypatch.setattr(routes_module, "CLEANUP_DELAY_SECONDS", 0.2)
+
+        try:
+            # Using TestClient as a context manager keeps the lifespan loop alive long
+            # enough for the background cleanup task to complete.
+            with client:
+                resp = client.get("/api/download/job_owned", headers={"x-api-key": "test-key"})
+                assert resp.status_code == 200
+                assert resp.content.startswith(b"PK")
+                assert "scraped-content-job_owned.zip" in resp.headers.get("content-disposition", "")
+
+                deadline = time.time() + 3
+                while time.time() < deadline and (
+                    zip_file.exists() or "job_owned" in routes_module._results
+                ):
+                    time.sleep(0.05)
+
+            assert not zip_file.exists()
+            assert "job_owned" not in routes_module._results
+        finally:
+            routes_module._results.pop("job_owned", None)
+
+    def test_download_cleanup_handles_missing_file(self, client, monkeypatch, tmp_path, caplog):
+        """Cleanup must not raise even if the zip file is already gone."""
+        import logging
+        import time
+        import link_content_scraper.routes as routes_module
+
+        self._setup_auth_mock(monkeypatch)
+
+        zip_file = tmp_path / "vanish.zip"
+        zip_file.write_bytes(b"PK\x03\x04")
+        routes_module._results["job_vanish"] = {
+            "zip_path": str(zip_file),
+            "customer_id": "cus_test",
+        }
+        monkeypatch.setattr(routes_module, "CLEANUP_DELAY_SECONDS", 0.2)
+
+        # Force unlink to raise OSError to exercise the `except OSError` branch
+        original_unlink = routes_module.Path.unlink
+
+        def _raising_unlink(self, missing_ok=False):
+            if str(self) == str(zip_file):
+                raise OSError("simulated unlink failure")
+            return original_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(routes_module.Path, "unlink", _raising_unlink)
+
+        try:
+            with client:
+                with caplog.at_level(logging.WARNING, logger="link_content_scraper.routes"):
+                    resp = client.get("/api/download/job_vanish", headers={"x-api-key": "test-key"})
+                assert resp.status_code == 200
+
+                deadline = time.time() + 3
+                while time.time() < deadline and "job_vanish" in routes_module._results:
+                    time.sleep(0.05)
+
+            assert "job_vanish" not in routes_module._results
+            assert any("Failed to clean up" in m for m in caplog.messages)
+        finally:
+            routes_module._results.pop("job_vanish", None)
+
+
+class TestBillingPages:
+    def test_billing_page_returns_html(self, client):
+        resp = client.get("/billing")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+    def test_billing_success_page_returns_html(self, client):
+        resp = client.get("/billing/success")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+
+class TestCheckoutEndpoint:
+    def test_checkout_returns_url(self, client, monkeypatch):
+        import link_content_scraper.routes as routes_module
+
+        async def _create_session(tier, email):
+            return f"https://checkout.test/{tier}/{email}"
+
+        monkeypatch.setattr(routes_module, "create_checkout_session", _create_session)
+
+        resp = client.post(
+            "/api/billing/checkout",
+            json={"tier": "starter", "email": "buyer@example.com"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"url": "https://checkout.test/starter/buyer@example.com"}
+
+
+class TestPortalEndpoint:
+    def test_portal_requires_auth(self, client):
+        resp = client.get("/billing/portal")
+        assert resp.status_code == 401
+
+    def test_portal_returns_url_when_authed(self, client, monkeypatch):
+        import link_content_scraper.auth as auth_module
+        import link_content_scraper.routes as routes_module
+
+        _customer = Customer(stripe_customer_id="cus_test", email="t@t.com", tier="pro", active=True)
+
+        class _MockDb:
+            async def get_customer_by_key(self, key_hash):
+                return _customer
+
+            async def get_usage(self, customer_id, month):
+                return 0
+
+        monkeypatch.setattr(auth_module, "db_client", _MockDb())
+
+        async def _portal(stripe_customer_id):
+            return f"https://billing.test/{stripe_customer_id}"
+
+        monkeypatch.setattr(routes_module, "create_portal_session", _portal)
+
+        resp = client.get("/billing/portal", headers={"x-api-key": "test-key"})
+        assert resp.status_code == 200
+        assert resp.json() == {"url": "https://billing.test/cus_test"}
+
+
+class TestStripeWebhookEndpoint:
+    def test_webhook_returns_400_on_invalid_signature(self, client, monkeypatch):
+        import link_content_scraper.routes as routes_module
+
+        async def _raise(payload, sig_header):
+            raise ValueError("bad signature")
+
+        monkeypatch.setattr(routes_module, "handle_webhook", _raise)
+
+        resp = client.post(
+            "/api/webhooks/stripe",
+            content=b"raw-payload",
+            headers={"stripe-signature": "bad"},
+        )
+        assert resp.status_code == 400
+        assert "bad signature" in resp.json()["detail"]
+
+    def test_webhook_returns_200_on_success(self, client, monkeypatch):
+        import link_content_scraper.routes as routes_module
+
+        async def _ok(payload, sig_header):
+            return None
+
+        monkeypatch.setattr(routes_module, "handle_webhook", _ok)
+
+        resp = client.post(
+            "/api/webhooks/stripe",
+            content=b"raw-payload",
+            headers={"stripe-signature": "sig_test"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+
+class TestFreeSignupRollback:
+    def _install_db(self, monkeypatch, db):
+        import link_content_scraper.auth as auth_module
+        import link_content_scraper.routes as routes_module
+        monkeypatch.setattr(auth_module, "db_client", db)
+        monkeypatch.setattr(routes_module, "db_client", db)
+
+    def test_create_api_key_failure_triggers_rollback_and_returns_500(self, client, monkeypatch, caplog):
+        import logging
+
+        class _MockDb:
+            def __init__(self):
+                self.customers = {}
+                self.deleted = []
+
+            async def get_customer_by_email(self, email):
+                return None
+
+            async def create_customer(self, customer_id, email, tier):
+                self.customers[customer_id] = {"email": email, "tier": tier}
+
+            async def create_api_key(self, key_hash, customer_id):
+                raise RuntimeError("api key insert failed")
+
+            async def store_pending_key(self, *args, **kwargs):
+                pass
+
+            async def delete_customer(self, customer_id):
+                self.deleted.append(customer_id)
+                self.customers.pop(customer_id, None)
+
+        db = _MockDb()
+        self._install_db(monkeypatch, db)
+
+        with caplog.at_level(logging.ERROR, logger="link_content_scraper.routes"):
+            resp = client.post("/api/signup/free", json={"email": "rollback@example.com"})
+
+        assert resp.status_code == 500
+        assert "Account creation failed" in resp.json()["detail"]
+        assert len(db.deleted) == 1, "delete_customer must run as rollback"
+
+    def test_rollback_failure_is_logged_and_still_returns_500(self, client, monkeypatch, caplog):
+        import logging
+
+        class _MockDb:
+            def __init__(self):
+                self.customers = {}
+
+            async def get_customer_by_email(self, email):
+                return None
+
+            async def create_customer(self, customer_id, email, tier):
+                self.customers[customer_id] = {"email": email, "tier": tier}
+
+            async def create_api_key(self, key_hash, customer_id):
+                raise RuntimeError("api key insert failed")
+
+            async def store_pending_key(self, *args, **kwargs):
+                pass
+
+            async def delete_customer(self, customer_id):
+                raise RuntimeError("delete failed too")
+
+        db = _MockDb()
+        self._install_db(monkeypatch, db)
+
+        with caplog.at_level(logging.ERROR, logger="link_content_scraper.routes"):
+            resp = client.post("/api/signup/free", json={"email": "rollback2@example.com"})
+
+        assert resp.status_code == 500
+        assert any("manual cleanup" in m for m in caplog.messages)
+
+
 class TestSSEEventSchema:
     """Task link_content_scraper-8io: SSE events must include all required fields."""
 

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -10,7 +10,12 @@ from bs4 import BeautifulSoup
 
 from link_content_scraper.progress import ProgressTracker
 from link_content_scraper.rate_limit import RateLimiter
-from link_content_scraper.scraper import create_zip_file, extract_content_links, get_markdown_content
+from link_content_scraper.scraper import (
+    create_zip_file,
+    extract_content_links,
+    get_markdown_content,
+    scrape_site,
+)
 
 
 # -- extract_content_links -----------------------------------------------------
@@ -258,3 +263,361 @@ class TestGetMarkdownContent:
         assert content == ""
         state = await fresh_tracker.get("t1")
         assert state["failed"] == 1
+
+    async def test_arxiv_url_is_transformed_and_logged(
+        self, monkeypatch, fresh_tracker, fast_limiter, caplog
+    ):
+        import logging
+
+        monkeypatch.setattr("link_content_scraper.scraper.progress_tracker", fresh_tracker)
+        monkeypatch.setattr("link_content_scraper.scraper.rate_limiter", fast_limiter)
+        await fresh_tracker.init("t1", total=1)
+
+        seen = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(str(request.url))
+            return httpx.Response(200, text=JINA_VALID_RESPONSE)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            with caplog.at_level(logging.INFO, logger="link_content_scraper.scraper"):
+                url, content = await get_markdown_content(
+                    "https://arxiv.org/abs/2401.12345", client, "t1"
+                )
+        assert content
+        assert any(".pdf" in u for u in seen), f"Expected transformed PDF URL in {seen}"
+        assert any("URL transformation" in m for m in caplog.messages)
+
+    async def test_increment_usage_failure_does_not_break_fetch(
+        self, monkeypatch, fresh_tracker, fast_limiter, caplog
+    ):
+        import logging
+        from link_content_scraper import scraper as scraper_module
+
+        monkeypatch.setattr(scraper_module, "progress_tracker", fresh_tracker)
+        monkeypatch.setattr(scraper_module, "rate_limiter", fast_limiter)
+
+        class _BoomDb:
+            async def increment_usage(self, customer_id, month):
+                raise RuntimeError("usage table down")
+
+        monkeypatch.setattr(scraper_module, "db_client", _BoomDb())
+
+        await fresh_tracker.init("t1", total=1)
+        transport = _make_transport([(200, JINA_VALID_RESPONSE)])
+        async with httpx.AsyncClient(transport=transport) as client:
+            with caplog.at_level(logging.ERROR, logger="link_content_scraper.scraper"):
+                url, content = await get_markdown_content(
+                    "https://example.com/usage-fail", client, "t1", customer_id="cus_x"
+                )
+        assert content, "Fetch must succeed even if usage tracking fails"
+        assert any("Failed to increment usage" in m for m in caplog.messages)
+
+    async def test_non_200_non_429_raises_and_retries(
+        self, monkeypatch, fresh_tracker, fast_limiter
+    ):
+        monkeypatch.setattr("link_content_scraper.scraper.progress_tracker", fresh_tracker)
+        monkeypatch.setattr("link_content_scraper.scraper.rate_limiter", fast_limiter)
+        monkeypatch.setattr("link_content_scraper.scraper.RETRY_DELAY", 0)
+        monkeypatch.setattr("link_content_scraper.scraper.MAX_RETRIES", 1)
+
+        await fresh_tracker.init("t1", total=1)
+        # 500 then 500 — both raise httpx.HTTPStatusError, which is caught and retried
+        transport = _make_transport([(500, "boom"), (500, "boom")])
+        async with httpx.AsyncClient(transport=transport) as client:
+            url, content = await get_markdown_content(
+                "https://example.com/server-error", client, "t1"
+            )
+        assert content == ""
+        state = await fresh_tracker.get("t1")
+        assert state["failed"] == 1
+
+    async def test_increment_usage_called_for_authenticated_customer(
+        self, monkeypatch, fresh_tracker, fast_limiter
+    ):
+        from link_content_scraper import scraper as scraper_module
+
+        monkeypatch.setattr(scraper_module, "progress_tracker", fresh_tracker)
+        monkeypatch.setattr(scraper_module, "rate_limiter", fast_limiter)
+
+        calls = []
+
+        class _OkDb:
+            async def increment_usage(self, customer_id, month):
+                calls.append((customer_id, month))
+
+        monkeypatch.setattr(scraper_module, "db_client", _OkDb())
+        await fresh_tracker.init("t1", total=1)
+
+        transport = _make_transport([(200, JINA_VALID_RESPONSE)])
+        async with httpx.AsyncClient(transport=transport) as client:
+            await get_markdown_content(
+                "https://example.com/track", client, "t1", customer_id="cus_track"
+            )
+        assert len(calls) == 1
+        assert calls[0][0] == "cus_track"
+
+    async def test_cancellation_between_retries_returns_early(
+        self, monkeypatch, fresh_tracker, fast_limiter
+    ):
+        """Cancel between iterations of the retry loop — line 88-89 cancellation check inside while loop."""
+        monkeypatch.setattr("link_content_scraper.scraper.progress_tracker", fresh_tracker)
+        monkeypatch.setattr("link_content_scraper.scraper.rate_limiter", fast_limiter)
+        monkeypatch.setattr("link_content_scraper.scraper.RETRY_DELAY", 0)
+        monkeypatch.setattr("link_content_scraper.scraper.MAX_RETRIES", 5)
+
+        await fresh_tracker.init("t1", total=1)
+
+        call_count = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            call_count["n"] += 1
+            return httpx.Response(429, text="rate limited")
+
+        transport = httpx.MockTransport(handler)
+
+        # Patch is_cancelled so it returns True on the SECOND call (i.e. after the first
+        # 429 response triggers a retry, the next iteration's cancellation check trips).
+        original_is_cancelled = fresh_tracker.is_cancelled
+        check_count = {"n": 0}
+
+        async def _is_cancelled(tracker_id):
+            check_count["n"] += 1
+            # First check is at line 74 (before loop). Second check is at line 88 (in loop).
+            # After we've made one HTTP call, cancel.
+            if call_count["n"] >= 1 and check_count["n"] >= 2:
+                return True
+            return await original_is_cancelled(tracker_id)
+
+        monkeypatch.setattr(fresh_tracker, "is_cancelled", _is_cancelled)
+
+        transport_response = _make_transport([(429, "x"), (429, "x")])
+        async with httpx.AsyncClient(transport=transport_response) as client:
+            url, content = await get_markdown_content(
+                "https://example.com/cancel-mid", client, "t1"
+            )
+        assert content == ""
+
+
+# -- scrape_site full pipeline -------------------------------------------------
+
+INDEX_HTML = """
+<html><body>
+  <main>
+    {links}
+  </main>
+</body></html>
+"""
+
+
+def _index_page(link_urls: list[str]) -> str:
+    anchors = "\n".join(f'<a href="{u}">page</a>' for u in link_urls)
+    return INDEX_HTML.format(links=anchors)
+
+
+class TestScrapeSite:
+    async def test_basic_scrape_returns_urls_and_zip(
+        self, monkeypatch, fresh_tracker, fast_limiter, tmp_path
+    ):
+        from link_content_scraper import scraper as scraper_module
+
+        monkeypatch.setattr(scraper_module, "progress_tracker", fresh_tracker)
+        monkeypatch.setattr(scraper_module, "rate_limiter", fast_limiter)
+
+        sub = "https://example.com/sub1"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if url == "https://example.com/":
+                return httpx.Response(200, text=_index_page([sub]))
+            # Otherwise, treat as Jina request
+            return httpx.Response(200, text=JINA_VALID_RESPONSE)
+
+        transport = httpx.MockTransport(handler)
+
+        async def _runner():
+            # Patch httpx.AsyncClient inside scraper to use our transport
+            import httpx as httpx_mod
+            original = httpx_mod.AsyncClient
+
+            class _Patched(original):
+                def __init__(self, *args, **kwargs):
+                    kwargs["transport"] = transport
+                    super().__init__(*args, **kwargs)
+
+            monkeypatch.setattr(scraper_module.httpx, "AsyncClient", _Patched)
+            urls, zip_path = await scrape_site(
+                "https://example.com/", "trk1", "job_basic", customer_id=None
+            )
+            return urls, zip_path
+
+        urls, zip_path = await _runner()
+        try:
+            assert urls[0] == "https://example.com/"
+            assert sub in urls
+            assert Path(zip_path).exists()
+        finally:
+            Path(zip_path).unlink(missing_ok=True)
+
+    async def test_scrape_site_runs_two_batches_with_sleep(
+        self, monkeypatch, fresh_tracker, fast_limiter, tmp_path
+    ):
+        """With BATCH_SIZE=2 and 4 links, scrape_site must process two batches and sleep between them (line 236)."""
+        from link_content_scraper import scraper as scraper_module
+
+        monkeypatch.setattr(scraper_module, "progress_tracker", fresh_tracker)
+        monkeypatch.setattr(scraper_module, "rate_limiter", fast_limiter)
+        monkeypatch.setattr(scraper_module, "BATCH_SIZE", 2)
+        monkeypatch.setattr(scraper_module, "RATE_PERIOD", 0)  # so sleep is essentially instant
+
+        sleeps: list[float] = []
+        original_sleep = scraper_module.asyncio.sleep
+
+        async def _spy_sleep(secs):
+            sleeps.append(secs)
+            await original_sleep(0)
+
+        monkeypatch.setattr(scraper_module.asyncio, "sleep", _spy_sleep)
+
+        sub_urls = [f"https://example.com/sub{i}" for i in range(4)]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if str(request.url) == "https://example.com/":
+                return httpx.Response(200, text=_index_page(sub_urls))
+            return httpx.Response(200, text=JINA_VALID_RESPONSE)
+
+        transport = httpx.MockTransport(handler)
+
+        import httpx as httpx_mod
+        original = httpx_mod.AsyncClient
+
+        class _Patched(original):
+            def __init__(self, *args, **kwargs):
+                kwargs["transport"] = transport
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(scraper_module.httpx, "AsyncClient", _Patched)
+
+        urls, zip_path = await scrape_site(
+            "https://example.com/", "trk2", "job_batches", customer_id=None
+        )
+        try:
+            assert len(urls) == 5  # original + 4 sub
+            # Inter-batch sleep is RATE_PERIOD/2 = 0; verify it was called at least once
+            assert any(s == 0 for s in sleeps)
+        finally:
+            Path(zip_path).unlink(missing_ok=True)
+
+    async def test_scrape_site_breaks_when_cancelled_between_batches(
+        self, monkeypatch, fresh_tracker, fast_limiter
+    ):
+        """Cancellation between batches must short-circuit the for loop (line 218)."""
+        from link_content_scraper import scraper as scraper_module
+
+        monkeypatch.setattr(scraper_module, "progress_tracker", fresh_tracker)
+        monkeypatch.setattr(scraper_module, "rate_limiter", fast_limiter)
+        monkeypatch.setattr(scraper_module, "BATCH_SIZE", 1)
+        monkeypatch.setattr(scraper_module, "RATE_PERIOD", 0)
+
+        sub_urls = [f"https://example.com/sub{i}" for i in range(3)]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if str(request.url) == "https://example.com/":
+                return httpx.Response(200, text=_index_page(sub_urls))
+            return httpx.Response(200, text=JINA_VALID_RESPONSE)
+
+        transport = httpx.MockTransport(handler)
+
+        import httpx as httpx_mod
+        original = httpx_mod.AsyncClient
+
+        class _Patched(original):
+            def __init__(self, *args, **kwargs):
+                kwargs["transport"] = transport
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(scraper_module.httpx, "AsyncClient", _Patched)
+
+        # Patch is_cancelled to return True on the second call to short-circuit batch loop
+        check_count = {"n": 0}
+        original_is_cancelled = fresh_tracker.is_cancelled
+
+        async def _is_cancelled(tracker_id):
+            check_count["n"] += 1
+            # Allow initial fetches but cancel before all batches complete.
+            # The first batch processes one link (sub0), then the second batch's cancel-check trips.
+            if check_count["n"] > 4:
+                return True
+            return await original_is_cancelled(tracker_id)
+
+        monkeypatch.setattr(fresh_tracker, "is_cancelled", _is_cancelled)
+
+        # Pre-init tracker so create_zip_file step has at least one valid result
+        try:
+            urls, zip_path = await scrape_site(
+                "https://example.com/", "trk_cancel", "job_cancel", customer_id=None
+            )
+            try:
+                # All 3 sub URLs are returned as the link list, but not all were processed
+                assert len(urls) == 4  # original + 3 sub
+            finally:
+                Path(zip_path).unlink(missing_ok=True)
+        except ValueError:
+            # If cancellation prevents any successful content, create_zip_file raises.
+            # That's an acceptable outcome for this branch — the cancel path was still hit.
+            pass
+
+    async def test_scrape_site_handles_exception_from_task(
+        self, monkeypatch, fresh_tracker, fast_limiter, caplog
+    ):
+        """An exception from a batch task must be logged and counted as failed (lines 231-233)."""
+        import logging
+        from link_content_scraper import scraper as scraper_module
+
+        monkeypatch.setattr(scraper_module, "progress_tracker", fresh_tracker)
+        monkeypatch.setattr(scraper_module, "rate_limiter", fast_limiter)
+        monkeypatch.setattr(scraper_module, "BATCH_SIZE", 5)
+        monkeypatch.setattr(scraper_module, "RATE_PERIOD", 0)
+
+        sub_urls = ["https://example.com/sub0", "https://example.com/sub1"]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if str(request.url) == "https://example.com/":
+                return httpx.Response(200, text=_index_page(sub_urls))
+            return httpx.Response(200, text=JINA_VALID_RESPONSE)
+
+        transport = httpx.MockTransport(handler)
+
+        import httpx as httpx_mod
+        original = httpx_mod.AsyncClient
+
+        class _Patched(original):
+            def __init__(self, *args, **kwargs):
+                kwargs["transport"] = transport
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(scraper_module.httpx, "AsyncClient", _Patched)
+
+        # Patch get_markdown_content so the first sub URL raises a regular Exception
+        # — gather(return_exceptions=True) collects it, then the dispatch loop
+        # logs it and increments the failed counter.
+        original_fn = scraper_module.get_markdown_content
+
+        async def _flaky_fn(url, client, tracker_id, customer_id=None):
+            if "sub0" in url:
+                raise RuntimeError("simulated task failure")
+            return await original_fn(url, client, tracker_id, customer_id)
+
+        monkeypatch.setattr(scraper_module, "get_markdown_content", _flaky_fn)
+
+        with caplog.at_level(logging.ERROR, logger="link_content_scraper.scraper"):
+            urls, zip_path = await scrape_site(
+                "https://example.com/", "trk_base", "job_base", customer_id=None
+            )
+        try:
+            assert any("Unhandled task exception" in m for m in caplog.messages)
+            state = await fresh_tracker.get("trk_base")
+            assert state["failed"] >= 1
+        finally:
+            Path(zip_path).unlink(missing_ok=True)


### PR DESCRIPTION
Added 63 new tests covering previously untested branches: DatabaseClient
methods (Supabase fluent-API mock), Stripe webhook payload-parse and
provisioning-failure paths, scrape route HTTPStatusError dispatch and
download cleanup, billing pages and portal/checkout endpoints,
free-signup rollback (including failed rollback), arXiv URL transform
logging, increment_usage failure isolation, batch-loop cancellation and
inter-batch sleep, gather() exception dispatch, register_tasks for an
unknown tracker, and Sentry init failure handling.

Coverage went from 85% -> 100% with all 235 tests passing.